### PR TITLE
allows admins / mods to manage tags

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,0 +1,5 @@
+@charset "utf-8";
+@import "bourbon";
+@import "base/base";
+@import "shared/shared";
+@import "pages/admin/pages";

--- a/app/assets/stylesheets/pages/admin/_pages.scss
+++ b/app/assets/stylesheets/pages/admin/_pages.scss
@@ -1,0 +1,1 @@
+@import "tags";

--- a/app/assets/stylesheets/pages/admin/_tags.scss
+++ b/app/assets/stylesheets/pages/admin/_tags.scss
@@ -1,0 +1,26 @@
+.tag-form {
+  .tag_kind {
+    margin-bottom: $spacing-xs;
+    label {
+      display: block;
+      margin-bottom: 0;
+    }
+  }
+}
+
+.tag-table-header {
+  display: inline;
+}
+
+.new-tag {
+  text-decoration: none;
+  float: right;
+}
+
+.no-tags {
+  text-align: center;
+}
+
+.tag-table {
+  margin-bottom: $spacing-small;
+}

--- a/app/assets/stylesheets/shared/_breadcrumbs.scss
+++ b/app/assets/stylesheets/shared/_breadcrumbs.scss
@@ -1,0 +1,5 @@
+.breadcrumb {
+  a {
+    text-decoration: none;
+  }
+}

--- a/app/assets/stylesheets/shared/_navbar.scss
+++ b/app/assets/stylesheets/shared/_navbar.scss
@@ -55,6 +55,37 @@
             }
           }
         }
+        .dropdown {
+          .dropbtn {
+            border: none;
+            outline: none;
+            color: $gray;
+            background-color: inherit;
+            font-family: inherit;
+            font-weight: inherit;
+            margin: inherit;
+            padding: inherit;
+          }
+          .dropdown-content {
+            display: none;
+            position: absolute;
+            box-shadow: $box-shadow;
+            z-index: 1;
+            a {
+              color: $gray;
+              padding: 0 1rem;
+              text-decoration: none;
+              display: block;
+              text-align: left;
+            }
+            a:hover {
+              background-color: $action-color--alt;
+            }
+          }
+        }
+        .dropdown:hover .dropdown-content {
+          display: block;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/shared/_shared.scss
+++ b/app/assets/stylesheets/shared/_shared.scss
@@ -4,3 +4,4 @@
 @import "pagination";
 @import "tags";
 @import "votes";
+@import "breadcrumbs";

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,12 @@
+module Admin
+  class BaseController < ApplicationController
+    before_action :authenticate_admin!
+
+    private
+
+    def authenticate_admin!
+      authenticate_user!
+      head :forbidden unless current_user.admin? || current_user.moderator?
+    end
+  end
+end

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -1,0 +1,43 @@
+module Admin
+  class TagsController < BaseController
+    def index
+      @grouped_tags = Tag.order(:description).to_a.group_by(&:kind)
+    end
+
+    def new
+      @tag = Tag.new(kind: params[:kind])
+    end
+
+    def edit
+      @tag = Tag.find(params[:id])
+    end
+
+    def create
+      @tag = Tag.create(create_tag_params)
+      if @tag.errors.none?
+        redirect_to admin_tags_path, notice: t(".success")
+      else
+        render :new
+      end
+    end
+
+    def update
+      @tag = Tag.find(params[:id])
+      if @tag.update(update_tag_params)
+        redirect_to admin_tags_path, notice: t(".success")
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def create_tag_params
+      params.require(:tag).permit(:id, :kind, :description)
+    end
+
+    def update_tag_params
+      params.require(:tag).permit(:kind, :description)
+    end
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,5 @@
 class Tag < ApplicationRecord
+  ID_REGEX = /\A[a-z]+(-[a-z0-9]+|[a-z0-9])*\z/.freeze
   enum kind: {
     topic: 0,
     media: 5,
@@ -6,6 +7,8 @@ class Tag < ApplicationRecord
     meta: 15,
     mod: 20
   }
+
+  validate :validate_tag_id_format
 
   has_many :submission_tags
   has_many :submissions, through: :submission_tags
@@ -15,6 +18,14 @@ class Tag < ApplicationRecord
       Tag.all
     else
       Tag.where.not(kind: :mod)
+    end
+  end
+
+  private
+
+  def validate_tag_id_format
+    unless id.match?(ID_REGEX)
+      errors.add(:id, "ID must match format: #{ID_REGEX.inspect}")
     end
   end
 end

--- a/app/views/admin/tags/_form.html.haml
+++ b/app/views/admin/tags/_form.html.haml
@@ -1,0 +1,5 @@
+= simple_form_for [:admin, tag] do |f|
+  = f.input :id, disabled: tag.persisted?
+  = f.input :kind, collection: Tag.kinds.keys, include_blank: false
+  = f.input :description
+  = f.button :submit

--- a/app/views/admin/tags/edit.html.haml
+++ b/app/views/admin/tags/edit.html.haml
@@ -1,0 +1,5 @@
+%h1.breadcrumb
+  = link_to t("admin.tags.index.title"), admin_tags_path
+  = "/ #{t('.title')}"
+.tag-form
+  = render "form", tag: @tag

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -1,0 +1,20 @@
+%h1= t(".title")
+- Tag.kinds.each_key do |tag_kind|
+  .tag-table{ class: "#{tag_kind}-tag-table" }
+    %h2.tag-table-header= t(".#{tag_kind}")
+    = link_to t(".new_#{tag_kind}_tag"), new_admin_tag_path(kind: tag_kind), class: "new-tag"
+    %table
+      %thead
+        %tr
+          %td= t(".id")
+          %td= t(".description")
+          %td= t(".actions")
+      %tbody
+        - if @grouped_tags[tag_kind].present?
+          - @grouped_tags[tag_kind].each do |tag|
+            %tr
+              %td= render "shared/tag", tag: tag
+              %td= tag.description
+              %td= link_to t(".edit"), edit_admin_tag_path(tag.id)
+    - if @grouped_tags[tag_kind].blank?
+      .no-tags= t(".no_tags")

--- a/app/views/admin/tags/new.html.haml
+++ b/app/views/admin/tags/new.html.haml
@@ -1,0 +1,5 @@
+%h1.breadcrumb
+  = link_to t("admin.tags.index.title"), admin_tags_path
+  = "/ #{t('.title')}"
+.tag-form
+  = render "form", tag: @tag

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,5 +1,9 @@
 .footer
   - if current_user.present?
+    - if current_user.admin? || current_user.moderator?
+      .footer-links
+        %ul
+          %li= link_to t("footer.admin_menu.tags"), admin_tags_path
     .footer-links
       %ul
         %li= link_to t("footer.submissions.user"), user_submissions_path(current_user.username)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,11 @@
     %title SimpleGroup
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
+    - if controller_path =~ /admin/
+      = stylesheet_link_tag "admin", media: "all", "data-turbolinks-track": "reload"
+    - else
+      = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
+
     = javascript_pack_tag "application", "data-turbolinks-track": "reload"
     - if content_for?(:page_styles)
       = yield :page_styles

--- a/config/locales/navigation.en.yml
+++ b/config/locales/navigation.en.yml
@@ -14,3 +14,5 @@ en:
           rules: "Rules"
           source: "GitHub"
           sign_out: "Sign Out"
+      admin_menu:
+          tags: Tags

--- a/config/locales/tags.en.yml
+++ b/config/locales/tags.en.yml
@@ -1,0 +1,28 @@
+en:
+  admin:
+    tags:
+      index:
+        topic: Topic Tags
+        new_topic_tag: + Add topic tag
+        media: Media Tags
+        new_media_tag: + Add media tag
+        source: Source Tags
+        new_source_tag: + Add source tag
+        meta: Meta Tags
+        new_meta_tag: + Add meta tag
+        mod: Mod Tags
+        new_mod_tag: + Add mod tag
+        title: Tags Admin
+        id: ID
+        description: Description
+        actions: Actions
+        edit: Edit
+        no_tags: No tags for this tag kind.
+      new:
+        title: Create Tag
+      edit:
+        title: Edit Tag
+      create:
+        success: Successfully created tag
+      update:
+        success: Successfully updated tag

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,10 @@ Rails.application.routes.draw do
 
   resources :user_invitations, only: [:create]
 
+  namespace :admin do
+    resources :tags, only: [:index, :new, :edit, :create, :update]
+  end
+
   namespace :api do
     namespace :v1 do
       resources :comments, only: [], param: :short_id do

--- a/spec/support/page_objects/admin/create_tag_page.rb
+++ b/spec/support/page_objects/admin/create_tag_page.rb
@@ -1,0 +1,21 @@
+require "support/page_objects/page_base"
+require "support/page_objects/shared_components/admin/tag_form"
+
+module Admin
+  class CreateTagPage < PageBase
+    include TagForm
+
+    def visit(as:)
+      login_as(as)
+      super(new_admin_tag_path)
+      self
+    end
+
+    def submit_form
+      within("form#new_tag") do
+        click_on "Create Tag"
+      end
+      self
+    end
+  end
+end

--- a/spec/support/page_objects/admin/edit_tag_page.rb
+++ b/spec/support/page_objects/admin/edit_tag_page.rb
@@ -1,0 +1,29 @@
+require "support/page_objects/page_base"
+require "support/page_objects/shared_components/admin/tag_form"
+
+module Admin
+  class EditTagPage < PageBase
+    include TagForm
+
+    def initialize(tag)
+      @tag = tag
+    end
+
+    def visit(as:)
+      login_as(as)
+      super(edit_admin_tag_path(tag))
+      self
+    end
+
+    def submit_form
+      within("form#edit_tag_#{tag.id}") do
+        click_on "Update Tag"
+      end
+      self
+    end
+
+    private
+
+    attr_reader :tag
+  end
+end

--- a/spec/support/page_objects/admin/tags_index_page.rb
+++ b/spec/support/page_objects/admin/tags_index_page.rb
@@ -1,0 +1,22 @@
+require "support/page_objects/page_base"
+
+module Admin
+  class TagsIndexPage < PageBase
+    def visit(as:)
+      login_as(as)
+      super(admin_tags_path)
+      self
+    end
+
+    def click_add_topic_tag
+      click_link "+ Add topic tag"
+      self
+    end
+
+    def has_tag_table_row?(tag)
+      within find(".#{tag.kind}-tag-table") do
+        has_css?("tbody tr td", text: tag.id)
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/shared_components/admin/tag_form.rb
+++ b/spec/support/page_objects/shared_components/admin/tag_form.rb
@@ -1,0 +1,16 @@
+module TagForm
+  def fill_in_id(id)
+    fill_in :tag_id, with: id
+    self
+  end
+
+  def select_tag_kind(kind)
+    select kind, from: "Kind"
+    self
+  end
+
+  def fill_in_description(description)
+    fill_in :tag_description, with: description
+    self
+  end
+end

--- a/spec/system/admin/admin_manages_tags_spec.rb
+++ b/spec/system/admin/admin_manages_tags_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe "Admin manages tags" do
+  let(:admin) { create(:user, :admin) }
+
+  context "when an admin visits the admin tags index" do
+    let(:page) { Admin::TagsIndexPage.new }
+
+    it "sees available tags grouped by kind" do
+      Tag.kinds.each_key { |kind| create(:"#{kind}_tag") }
+
+      page.visit(as: admin)
+
+      Tag.all.each do |tag|
+        expect(page).to have_tag_table_row(tag)
+      end
+    end
+
+    it "can add new tags by clicking the corresponding kind add link" do
+      page.visit(as: admin).click_add_topic_tag
+
+      expect(page).to have_current_path(new_admin_tag_path(kind: :topic))
+      expect(page).to have_select("Kind", selected: "topic")
+    end
+  end
+
+  context "when an admin fills out the new tag form" do
+    let(:page) { Admin::CreateTagPage.new }
+
+    context "when valid" do
+      it "creates the tag and redirects the admin" do
+        page.visit(as: admin).
+          fill_in_id("foo-bar").
+          select_tag_kind("topic").
+          fill_in_description("Fun").
+          submit_form
+
+        expect(Tag.count).to eq(1)
+
+        tag = Tag.first
+
+        expect(tag.id).to eq("foo-bar")
+        expect(tag).to be_topic
+        expect(tag.description).to eq("Fun")
+      end
+    end
+
+    context "when the ID is malformatted" do
+      it "renders the error" do
+      end
+    end
+  end
+
+  context "when an admin fills out the edit tag form" do
+    let(:tag) { create(:topic_tag) }
+    let(:page) { Admin::EditTagPage.new(tag) }
+
+    it "updates the tag" do
+      page.visit(as: admin).
+        select_tag_kind("meta").
+        fill_in_description("beep").
+        submit_form
+
+      tag.reload
+
+      expect(tag).to be_meta
+      expect(tag.description).to eq("beep")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/JSOQScjN

This commit adds some basic admin functionality
  that allows admins to view, add, and edit tags
  for submissions.

We don't allow doing things like deleting tags.