### PR TITLE
submission removals

### DIFF
--- a/app/assets/stylesheets/pages/_submissions.scss
+++ b/app/assets/stylesheets/pages/_submissions.scss
@@ -55,6 +55,12 @@
       content: "|";
     }
 
+    .submission-info {
+      .mod-action-removed {
+        font-style: italic;
+      }
+    }
+
     .submission-info a::after {
       @include margin(null 1px null null);
       @include padding(null null null 4px);

--- a/app/assets/stylesheets/pages/admin/_pages.scss
+++ b/app/assets/stylesheets/pages/admin/_pages.scss
@@ -1,1 +1,2 @@
 @import "tags";
+@import "submission_removals";

--- a/app/assets/stylesheets/pages/admin/_submission_removals.scss
+++ b/app/assets/stylesheets/pages/admin/_submission_removals.scss
@@ -1,0 +1,24 @@
+.submission-removal-container {
+  .submission, .removal-info {
+    border-bottom: $light-border;
+    padding-bottom: $spacing-small;
+    a {
+      text-decoration: none;
+    }
+  }
+
+  .submission_removal_reason {
+    margin-top: $spacing-small;
+    margin-bottom: $spacing-xs;
+    label {
+      display: block;
+      margin-bottom: 0;
+    }
+  }
+}
+
+.removal-table {
+  tr {
+    vertical-align: middle;
+  }
+}

--- a/app/controllers/admin/submission_removals_controller.rb
+++ b/app/controllers/admin/submission_removals_controller.rb
@@ -1,0 +1,57 @@
+module Admin
+  class SubmissionRemovalsController < BaseController
+    DEFAULT_PAGE = 0
+    DEFAULT_PER_PAGE = 25
+
+    def index
+      @paginator = ResultsPaginator.new(
+        SubmissionRemoval.includes(:removed_by, submission: :user),
+        pagination_params
+      )
+    end
+
+    def show
+      @removal = SubmissionRemoval.includes(:removed_by, submission: :user).find(params[:id])
+    end
+
+    def new
+      @submission = Submission.includes(:user).friendly.
+        find(submission_removal_params.delete(:submission_short_id))
+      @removal = SubmissionRemoval.new(submission_removal_params.merge(submission_id: @submission.id))
+    end
+
+    def create
+      Submission.friendly.find(submission_removal_params.delete(:submission_short_id)).then do |s|
+        s.update!(removed: true)
+        SubmissionRemoval.where(submission: s).
+          first_or_create!(submission_removal_params.merge(removed_by: current_user))
+      end
+
+      redirect_to admin_submission_removals_path, notice: t(".success")
+    end
+
+    def destroy
+      removal = SubmissionRemoval.includes(:submission).find(params[:id])
+      removal.submission.update!(removed: false)
+      removal.destroy!
+
+      redirect_to admin_submission_removals_path, notice: t(".success")
+    end
+
+    private
+
+    def pagination_params
+      {
+        page: params.fetch(:page, DEFAULT_PAGE),
+        per_page: params.fetch(:per_page, DEFAULT_PER_PAGE),
+        order: { created_at: :desc }
+      }
+    end
+
+    def submission_removal_params
+      @_submission_removal_params ||= params.
+        require(:submission_removal).
+        permit(:submission_short_id, :reason, :details)
+    end
+  end
+end

--- a/app/controllers/api/v1/comments/downvotes_controller.rb
+++ b/app/controllers/api/v1/comments/downvotes_controller.rb
@@ -12,6 +12,8 @@ module Api
                 status: :forbidden
             end
           end
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
         end
 
         private
@@ -54,13 +56,12 @@ module Api
         end
 
         def comment
-          @_comment ||= Comment.friendly.find(params[:comment_short_id])
+          @_comment ||= Comment.friendly.joins(:submission).
+            merge(Submission.visible).find(params[:comment_short_id])
         end
 
         def find_or_initialize_vote
           current_user.votes.comment.find_or_initialize_by(votable_id: comment.id)
-        rescue ActiveRecord::RecordNotFound
-          head :not_found
         end
       end
     end

--- a/app/controllers/api/v1/comments/upvotes_controller.rb
+++ b/app/controllers/api/v1/comments/upvotes_controller.rb
@@ -10,6 +10,8 @@ module Api
               handle_upvote(vote)
             end
           end
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
         end
 
         private
@@ -36,10 +38,8 @@ module Api
         end
 
         def find_or_initialize_vote
-          comment = Comment.friendly.find(params[:comment_short_id])
+          comment = Comment.friendly.joins(:submission).merge(Submission.visible).find(params[:comment_short_id])
           current_user.votes.comment.find_or_initialize_by(votable_id: comment.id)
-        rescue ActiveRecord::RecordNotFound
-          head :not_found
         end
       end
     end

--- a/app/controllers/api/v1/submissions/downvotes_controller.rb
+++ b/app/controllers/api/v1/submissions/downvotes_controller.rb
@@ -12,6 +12,8 @@ module Api
                 status: :forbidden
             end
           end
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
         end
 
         private
@@ -54,13 +56,11 @@ module Api
         end
 
         def submission
-          @_submission ||= Submission.friendly.find(params[:submission_short_id])
+          @_submission ||= Submission.visible.friendly.find(params[:submission_short_id])
         end
 
         def find_or_initialize_vote
           current_user.votes.submission.find_or_initialize_by(votable_id: submission.id)
-        rescue ActiveRecord::RecordNotFound
-          head :not_found
         end
       end
     end

--- a/app/controllers/api/v1/submissions/upvotes_controller.rb
+++ b/app/controllers/api/v1/submissions/upvotes_controller.rb
@@ -10,6 +10,8 @@ module Api
               handle_upvote(vote)
             end
           end
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
         end
 
         private
@@ -36,10 +38,8 @@ module Api
         end
 
         def find_or_initialize_vote
-          submission = Submission.friendly.find(params[:submission_short_id])
+          submission = Submission.visible.friendly.find(params[:submission_short_id])
           current_user.votes.submission.find_or_initialize_by(votable_id: submission.id)
-        rescue ActiveRecord::RecordNotFound
-          head :not_found
         end
       end
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,7 +2,7 @@ class CommentsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    submission = Submission.friendly.find(params[:submission_short_id])
+    submission = Submission.visible.friendly.find(params[:submission_short_id])
     @comment = build_comment_for(submission)
 
     if @comment.save

--- a/app/controllers/inbox/thread_reply_notifications_controller.rb
+++ b/app/controllers/inbox/thread_reply_notifications_controller.rb
@@ -24,10 +24,11 @@ module Inbox
     private
 
     def filtered_notifications(filter_form)
+      base_relation = current_user.flattened_thread_reply_notifications.visible
       if filter_form.dismissed
-        filter_by_reply_type(current_user.flattened_thread_reply_notifications, filter_form)
+        filter_by_reply_type(base_relation, filter_form)
       else
-        filter_by_reply_type(current_user.flattened_thread_reply_notifications.where(dismissed: false), filter_form)
+        filter_by_reply_type(base_relation.where(dismissed: false), filter_form)
       end
     end
 

--- a/app/controllers/users/submission_actions_controller.rb
+++ b/app/controllers/users/submission_actions_controller.rb
@@ -6,6 +6,8 @@ module Users
       else
         head :forbidden
       end
+    rescue ActiveRecord::RecordNotFound
+      head :not_found
     end
 
     private
@@ -27,7 +29,9 @@ module Users
     end
 
     def submission_action_params
-      params.require(:submission_action).permit(:submission_short_id, :kind)
+      params.require(:submission_action).permit(:submission_short_id, :kind).tap do |p|
+        p[:submission] = Submission.visible.friendly.find(p.delete(:submission_short_id))
+      end
     end
 
     def status_for_action(action)

--- a/app/models/flattened_submission.rb
+++ b/app/models/flattened_submission.rb
@@ -9,6 +9,7 @@ class FlattenedSubmission < ApplicationRecord
     class_name: "FlattenedComment",
     primary_key: :id,
     foreign_key: :submission_id
+  has_one :submission_removal, required: false, foreign_key: :submission_id
 
   self.primary_key = :id
 

--- a/app/models/flattened_thread_reply_notification.rb
+++ b/app/models/flattened_thread_reply_notification.rb
@@ -11,4 +11,11 @@ class FlattenedThreadReplyNotification < ApplicationRecord
 
   scope :comment_replies, -> { where.not(irtc_id: nil) }
   scope :submission_replies, -> { where(irtc_id: nil) }
+  scope :visible, lambda {
+    where(
+      Submission.
+      where(removed: false).
+      where("flattened_thread_reply_notifications.submission_id = submissions.id").arel.exists
+    )
+  }
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -8,6 +8,9 @@ class Submission < ApplicationRecord
   has_many :comments
   has_many :root_comments, -> { where(parent_id: nil) }, class_name: "Comment"
   has_many :votes, as: :votable
+  has_one :submission_removal, required: false
+
+  scope :visible, -> { where(removed: false) }
 
   def self.short_id_prefix
     :s_

--- a/app/models/submission_removal.rb
+++ b/app/models/submission_removal.rb
@@ -1,0 +1,10 @@
+class SubmissionRemoval < ApplicationRecord
+  belongs_to :submission
+  belongs_to :removed_by, class_name: :User
+
+  enum reason: {
+    off_topic: 0,
+    spam: 1,
+    doxxing: 666
+  }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,10 @@ class User < ApplicationRecord
     admin? || daily_invites_under_maximum?
   end
 
+  def has_mod_permissions?
+    admin? || moderator?
+  end
+
   private
 
   def daily_invites_under_maximum?

--- a/app/views/admin/submission_removals/index.html.haml
+++ b/app/views/admin/submission_removals/index.html.haml
@@ -1,0 +1,30 @@
+%h1= t(".title")
+
+%table.removal-table
+  %thead
+    %tr
+      %td= t(".submission_title")
+      %td= t(".submission_author")
+      %td= t(".removed_by")
+      %td= t(".reason")
+      %td= t(".details")
+      %td
+  %tbody
+    - @paginator.results_page.each do |removal|
+      %tr{ id: "removal_#{removal.id}" }
+        %td
+          = link_to removal.submission.title, submission_path(removal.submission.short_id)
+        %td
+          = link_to removal.submission.user.username,
+            user_submissions_path(removal.submission.user.username)
+        %td= removal.removed_by.username
+        %td= removal.reason
+        %td= truncate(removal.details)
+        %td
+          = link_to t(".view"), admin_submission_removal_path(removal)
+          = link_to t(".undo"), admin_submission_removal_path(removal),
+            data: { confirm: t(".confirm_reverse_removal") },
+            method: :delete
+= render "shared/pagination_controls",
+  paginator: @paginator,
+  path_helper: ->(params) { admin_submission_removals_path(params) }

--- a/app/views/admin/submission_removals/new.html.haml
+++ b/app/views/admin/submission_removals/new.html.haml
@@ -1,0 +1,17 @@
+%h1= t(".remove_submission")
+.submission-removal-container
+  .submission
+    %div
+      = t(".submission_title")
+      %span
+        = link_to @submission.title, submission_path(@submission.short_id)
+    %div
+      = t(".submission_author")
+      %span
+        = link_to @submission.user.username, user_submissions_path(@submission.user.username)
+
+  = simple_form_for [:admin, @removal] do |f|
+    = f.input :reason, collection: SubmissionRemoval.reasons.keys
+    = f.input :details
+    = f.input :submission_short_id, as: :hidden, input_html: { value: @submission.short_id }, wrapper: false
+    = f.button :submit, t(".submit")

--- a/app/views/admin/submission_removals/show.html.haml
+++ b/app/views/admin/submission_removals/show.html.haml
@@ -1,0 +1,23 @@
+%h1.breadcrumb
+  = link_to t("admin.submission_removals.index.title"), admin_submission_removals_path
+  = "/ #{t('.title')}"
+
+.submission-removal-container
+  .removal-info
+    %div
+      %label= t(".submission_title")
+      %span
+        = link_to @removal.submission.title, submission_path(@removal.submission.short_id)
+    %div
+      %label= t(".submission_author")
+      %span
+        = link_to @removal.submission.user.username, user_submissions_path(@removal.submission.user.username)
+    %div
+      %label= t(".removed_by")
+      %span= @removal.removed_by.username
+    %div
+      %label= t(".reason")
+      %span= @removal.reason
+    %div
+      %label= t(".details")
+      %span= @removal.details

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -4,6 +4,7 @@
       .footer-links
         %ul
           %li= link_to t("footer.admin_menu.tags"), admin_tags_path
+          %li= link_to t("footer.admin_menu.submission_removals"), admin_submission_removals_path
     .footer-links
       %ul
         %li= link_to t("footer.submissions.user"), user_submissions_path(current_user.username)

--- a/app/views/shared/_pagination_controls.html.haml
+++ b/app/views/shared/_pagination_controls.html.haml
@@ -1,8 +1,8 @@
 .pagination-controls
   - if paginator.page.positive?
     %span.pagination-back
-      = link_to t(".previous_page"), submissions_path(page: paginator.page - 1)
+      = link_to t(".previous_page"), path_helper.call(page: paginator.page - 1)
 
   - if paginator.page < paginator.max_page
     %span.pagination-forward
-      = link_to t(".next_page"), submissions_path(page: paginator.page + 1)
+      = link_to t(".next_page"), path_helper.call(page: paginator.page + 1)

--- a/app/views/submissions/_submission_list_item.html.haml
+++ b/app/views/submissions/_submission_list_item.html.haml
@@ -23,6 +23,15 @@
       %span.submission-info
         = link_to hide_link_text_for(submission), "", class: "hide"
         = link_to save_link_text_for(submission), "", class: "save"
+        - if current_user.present? && current_user.has_mod_permissions?
+          - if submission.removed
+            = link_to t(".actions.removed"),
+              admin_submission_removal_path(submission.submission_removal),
+              class: "mod-action-removed"
+          - else
+            = link_to t(".actions.remove"),
+              new_admin_submission_removal_path(submission_removal: { submission_short_id: submission.short_id }),
+              class: "mod-action-remove"
       %span.submission-comments
         = link_to t(".comments", count: submission.comment_count),
           submission_path(submission.short_id)

--- a/app/views/submissions/index.html.haml
+++ b/app/views/submissions/index.html.haml
@@ -1,4 +1,5 @@
 = render "submission_list", submissions: @paginator.results_page
-= render "shared/pagination_controls", paginator: @paginator
+= render "shared/pagination_controls", paginator: @paginator,
+  path_helper: ->(params) { submissions_path(params) }
 = javascript_pack_tag "submission_actions"
 = javascript_pack_tag "voting"

--- a/config/locales/navigation.en.yml
+++ b/config/locales/navigation.en.yml
@@ -16,3 +16,4 @@ en:
           sign_out: "Sign Out"
       admin_menu:
           tags: Tags
+          submission_removals: Submission Removals

--- a/config/locales/submission_removals.en.yml
+++ b/config/locales/submission_removals.en.yml
@@ -1,0 +1,29 @@
+en:
+  admin:
+    submission_removals:
+      index:
+        title: Submission Removals
+        submission_title: Title
+        submission_author: Author
+        removed_by: Removed By
+        reason: Reason
+        details: Details
+        view: View
+        undo: Undo
+        confirm_reverse_removal: Are you sure you want to reverse this removal?
+      show:
+        title: Submission Removal
+        submission_title: "Title:"
+        submission_author: "Author:"
+        removed_by: "Removed By:"
+        reason: "Reason:"
+        details: "Details:"
+      new:
+        remove_submission: Remove Submission
+        submission_title: "Title:"
+        submission_author: "Author:"
+        submit: Remove Submission
+      create:
+        success: Submission has been successfully removed.
+      destroy:
+        success: Submission removal has been successfully reversed.

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -11,6 +11,8 @@ en:
       authored_by: authored by
       ago: ago
       actions:
+        remove: remove
+        removed: removed
         created:
           hidden: hidden
           saved: saved

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   resources :user_invitations, only: [:create]
 
   namespace :admin do
+    resources :submission_removals, only: [:index, :show, :new, :create, :destroy]
     resources :tags, only: [:index, :new, :edit, :create, :update]
   end
 

--- a/db/migrate/20201012005703_add_removed_to_submissions.rb
+++ b/db/migrate/20201012005703_add_removed_to_submissions.rb
@@ -1,0 +1,6 @@
+class AddRemovedToSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :submissions, :removed, :boolean, null: false, default: false
+    add_index :submissions, :removed
+  end
+end

--- a/db/migrate/20201012005712_add_removed_to_comments.rb
+++ b/db/migrate/20201012005712_add_removed_to_comments.rb
@@ -1,0 +1,6 @@
+class AddRemovedToComments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :removed, :boolean, null: false, default: false
+    add_index :comments, :removed
+  end
+end

--- a/db/migrate/20201012010234_create_submission_removals.rb
+++ b/db/migrate/20201012010234_create_submission_removals.rb
@@ -1,0 +1,14 @@
+class CreateSubmissionRemovals < ActiveRecord::Migration[6.0]
+  def change
+    create_table :submission_removals do |t|
+      t.belongs_to :submission, null: false, index: false, foreign_key: { on_delete: :cascade }
+      t.belongs_to :removed_by, null: false, index: false, foreign_key: { to_table: :users, on_delete: :cascade }
+      t.integer :reason, null: false
+      t.text :details
+
+      t.timestamps
+    end
+
+    add_index :submission_removals, :submission_id, unique: true
+  end
+end

--- a/db/migrate/20201018194648_update_flattened_submissions_to_version_3.rb
+++ b/db/migrate/20201018194648_update_flattened_submissions_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateFlattenedSubmissionsToVersion3 < ActiveRecord::Migration[6.0]
+  def change
+    update_view :flattened_submissions, version: 3, revert_to_version: 2
+  end
+end

--- a/db/views/flattened_submissions_v03.sql
+++ b/db/views/flattened_submissions_v03.sql
@@ -1,0 +1,56 @@
+SELECT
+  submissions.id, submissions.short_id, submissions.removed, title, url, domains.name AS domain_name,
+  NULL AS body, users.username AS submitter_username, original_author, submissions.created_at,
+  (
+      SELECT COUNT(submission_id) AS comment_count
+      FROM comments
+      WHERE comments.submission_id = submissions.id
+    ) AS comment_count,
+  (
+    (
+      SELECT COUNT(votable_id)
+      FROM votes
+      WHERE votable_type = 'Submission'
+      AND votable_id = submissions.id AND kind = 0
+    ) -
+    (
+      SELECT COUNT(votable_id)
+      FROM votes
+      WHERE votable_type = 'Submission'
+      AND votable_id = submissions.id AND kind = 1
+    )
+  ) AS score
+FROM
+  submissions
+INNER JOIN users ON submissions.user_id = users.id
+INNER JOIN domains ON submissions.domain_id = domains.id
+WHERE submissions.domain_id IS NOT NULL
+
+UNION ALL
+
+SELECT
+  submissions.id, submissions.short_id, submissions.removed, title, NULL AS url, NULL AS domain_name,
+  submissions.body, users.username AS submitter_username, original_author, submissions.created_at,
+  (
+      SELECT COUNT(submission_id) AS comment_count
+      FROM comments
+      WHERE comments.submission_id = submissions.id
+    ) AS comment_count,
+  (
+    (
+      SELECT COUNT(votable_id)
+      FROM votes
+      WHERE votable_type = 'Submission'
+      AND votable_id = submissions.id AND kind = 0
+    ) -
+    (
+      SELECT COUNT(votable_id)
+      FROM votes
+      WHERE votable_type = 'Submission'
+      AND votable_id = submissions.id AND kind = 1
+    )
+  ) AS score
+FROM
+  submissions
+INNER JOIN users ON submissions.user_id = users.id
+WHERE submissions.domain_id IS NULL

--- a/spec/factories/submission_removals.rb
+++ b/spec/factories/submission_removals.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :submission_removal do
+    association :removed_by, factory: [:user, :admin]
+    association :submission, factory: [:submission, :removed]
+    reason { 1 }
+    details { "MyText" }
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -33,4 +33,8 @@ FactoryBot.define do
       submission.comments = build_list(:comment, evaluator.num_comments)
     end
   end
+
+  trait :removed do
+    removed { true }
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Comment, type: :model do
   it { should belong_to(:user) }
   it { should belong_to(:submission) }

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Domain, type: :model do
   it { should belong_to(:banned_by).class_name("User").optional }
   it { should have_many(:submissions) }

--- a/spec/models/submission_action_spec.rb
+++ b/spec/models/submission_action_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe SubmissionAction, type: :model do
   it do
     should belong_to(:submission).

--- a/spec/models/submission_removal_spec.rb
+++ b/spec/models/submission_removal_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe SubmissionRemoval, type: :model do
+  it { should belong_to(:submission) }
+  it { should belong_to(:removed_by).class_name(:User) }
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe Submission, type: :model do
   it { should have_many(:comments) }
   it { should have_many(:votes) }
 
+  describe "scopes" do
+    describe ".vislble" do
+      it "returns submissions that have not been removed" do
+        s1 = create(:submission)
+        create(:submission, :removed)
+
+        expect(Submission.visible).to eq([s1])
+      end
+    end
+  end
+
   describe ".short_id_prefix" do
     it "is :s_" do
       expect(Submission.short_id_prefix).to eq(:s_)

--- a/spec/models/user_invitation_spec.rb
+++ b/spec/models/user_invitation_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe UserInvitation, type: :model do
   describe "#send_invitation" do
     let(:invitation) { create(:user_invitation) }

--- a/spec/requests/api/v1/comments/downvotes_spec.rb
+++ b/spec/requests/api/v1/comments/downvotes_spec.rb
@@ -132,5 +132,17 @@ RSpec.describe "downvote comments" do
         expect(vote.votable_id).to eq(comment.id)
       end
     end
+
+    context "when the underlying submission for a comment has been removed" do
+      it "returns 404 not found" do
+        login_as(user)
+
+        comment.submission.update!(removed: true)
+
+        put "/api/v1/comments/#{comment.short_id}/downvotes"
+
+        expect(response).to be_not_found
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/comments/upvotes_spec.rb
+++ b/spec/requests/api/v1/comments/upvotes_spec.rb
@@ -77,5 +77,17 @@ RSpec.describe "upvote comments" do
         expect(vote.votable_id).to eq(comment.id)
       end
     end
+
+    context "when the underlying submission for a comment has been removed" do
+      it "returns 404 not found" do
+        login_as(user)
+
+        comment.submission.update!(removed: true)
+
+        put "/api/v1/comments/#{comment.short_id}/upvotes"
+
+        expect(response).to be_not_found
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/submissions/downvotes_spec.rb
+++ b/spec/requests/api/v1/submissions/downvotes_spec.rb
@@ -133,5 +133,17 @@ RSpec.describe "downvote submissions" do
         expect(vote.votable_id).to eq(submission.id)
       end
     end
+
+    context "when the submission has been removed" do
+      it "returns 404 not found" do
+        login_as(user)
+
+        submission.update!(removed: true)
+
+        put "/api/v1/submissions/#{submission.short_id}/downvotes"
+
+        expect(response).to be_not_found
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/submissions/upvotes_spec.rb
+++ b/spec/requests/api/v1/submissions/upvotes_spec.rb
@@ -77,5 +77,17 @@ RSpec.describe "upvote submissions" do
         expect(vote.votable_id).to eq(submission.id)
       end
     end
+
+    context "when the submission has been removed" do
+      it "returns 404 not found" do
+        login_as(user)
+
+        submission.update!(removed: true)
+
+        put "/api/v1/submissions/#{submission.short_id}/upvotes"
+
+        expect(response).to be_not_found
+      end
+    end
   end
 end

--- a/spec/requests/users/submission_actions_spec.rb
+++ b/spec/requests/users/submission_actions_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe "submission actions" do
         end
       end
 
+      context "when the underlying submission has been removed" do
+        it "returns 404 not found" do
+          submission = create(:submission_removal).submission
+
+          put "/users/submission_actions",
+            params: {
+              submission_action: {
+                submission_short_id: submission.short_id, kind: :hidden
+              }
+            }
+
+          expect(response).to be_not_found
+        end
+      end
+
       context "when the action does not exist" do
         it "creates it" do
           put "/users/submission_actions",

--- a/spec/support/page_objects/admin/remove_submission_page.rb
+++ b/spec/support/page_objects/admin/remove_submission_page.rb
@@ -1,0 +1,33 @@
+require "support/page_objects/page_base"
+
+module Admin
+  class RemoveSubmissionPage < PageBase
+    def initialize(submission)
+      @submission = submission
+    end
+
+    def visit(as:)
+      login_as(as)
+      super(new_admin_submission_removal_path(submission_removal: { submission_short_id: submission.short_id }))
+      self
+    end
+
+    def select_reason(reason)
+      select reason, from: :submission_removal_reason
+      self
+    end
+
+    def fill_in_details(details)
+      fill_in :submission_removal_details, with: details
+      self
+    end
+
+    def submit_form
+      click_on "Remove Submission"
+    end
+
+    private
+
+    attr_reader :submission
+  end
+end

--- a/spec/support/page_objects/admin/submission_removals_index_page.rb
+++ b/spec/support/page_objects/admin/submission_removals_index_page.rb
@@ -1,0 +1,23 @@
+require "support/page_objects/page_base"
+
+module Admin
+  class SubmissionRemovalsIndexPage < PageBase
+    def visit(as:)
+      login_as(as)
+      super(admin_submission_removals_path)
+      self
+    end
+
+    def undo_removal(removal)
+      within find("#removal_#{removal.id}") do
+        accept_confirm do
+          click_on "Undo"
+        end
+      end
+    end
+
+    def has_removal_row?(removal)
+      has_css?("#removal_#{removal.id}", wait: 0)
+    end
+  end
+end

--- a/spec/support/page_objects/submissions_index_page.rb
+++ b/spec/support/page_objects/submissions_index_page.rb
@@ -18,6 +18,12 @@ class SubmissionsIndexPage < PageBase
     end
   end
 
+  def click_remove_submission(submission)
+    within find("##{submission.short_id} .submission-line2") do
+      click_link t("submissions.submission_list_item.actions.remove")
+    end
+  end
+
   def has_submission_row_for?(submission)
     has_css?("##{submission.short_id}") &&
       has_correct_submission_info?(submission)

--- a/spec/system/admin/admin_removes_submission_spec.rb
+++ b/spec/system/admin/admin_removes_submission_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe "Admin removes submission" do
+  let(:admin) { create(:user, :admin) }
+  let!(:submission) { create(:submission, :url) }
+
+  context "when an admin clicks remove on a submission" do
+    let(:page) { SubmissionsIndexPage.new }
+
+    it "gets sent to the submission removal form page" do
+      page.visit(as: admin)
+
+      page.click_remove_submission(submission)
+
+      expect(page).to have_current_path(
+        new_admin_submission_removal_path(submission_removal: {
+          submission_short_id: submission.short_id
+        })
+      )
+    end
+  end
+
+  context "when an admin submits the submission removal form" do
+    let(:page) { Admin::RemoveSubmissionPage.new(submission) }
+
+    it "creates a submission removal record" do
+      page.visit(as: admin).select_reason("spam").fill_in_details("spammy mc spam stix").submit_form
+
+      expect(submission.reload).to be_removed
+      expect(submission.submission_removal.removed_by).to eq(admin)
+      expect(submission.submission_removal.details).to eq("spammy mc spam stix")
+      expect(submission.submission_removal).to be_spam
+    end
+  end
+
+  context "when an admin wants to reverse the removal", js: true do
+    let(:page) { Admin::SubmissionRemovalsIndexPage.new }
+
+    it "clicks the undo link on the submission index and confirms and undos the removal" do
+      removal = create(:submission_removal)
+      submission = removal.submission
+
+      expect(submission).to be_removed
+
+      page.visit(as: admin)
+
+      expect(page).to have_removal_row(removal)
+
+      page.undo_removal(removal)
+
+      expect(page).not_to have_removal_row(removal)
+
+      submission.reload
+
+      expect(SubmissionRemoval.where(id: removal.id)).not_to exist
+      expect(submission).not_to be_removed
+    end
+  end
+end

--- a/spec/system/submissions_index_spec.rb
+++ b/spec/system/submissions_index_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe "submissions index" do
       expect(find(".submissions-list ol li", match: :first)).
         to have_css(".submission-line1", text: submission.title)
     end
+
+    it "does not show removed submissions" do
+      submission = create(:submission_removal).submission
+
+      page = SubmissionsIndexPage.new
+
+      page.visit
+
+      expect(page).not_to have_submission_row_for(submission)
+    end
   end
 
   context "when paginating results" do


### PR DESCRIPTION
Admins + mods need to be able to remove submissions that
  break community rules / guidelines.

Examples of removable submissions include things like:

- spam
- off-topic content
- doxxing

More fine-grained permissions as to who can view removed submissions,
  who can view the removal details, etc. will come separately.