### PR TITLE
removes `recent` link from navbar

### DIFF
--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -13,7 +13,6 @@
     .navbar-links
       %ul
         %li
-          %span= link_to t("navigation.links.recent"), "#"
         - if current_user.present?
           %li
             %span= link_to t("navigation.links.submit"), new_submission_path


### PR DESCRIPTION
Until we figure out what kind of sorting we want to support, I'm
  removing the dead link to make things less confusing.